### PR TITLE
Update avatar preview js to only attach on appropriate pages

### DIFF
--- a/app/javascript/avatar_input_preview.js
+++ b/app/javascript/avatar_input_preview.js
@@ -1,8 +1,14 @@
 document.addEventListener("turbo:load", () => {
   const avatarInput = document.getElementById("avatar_input");
   const avatarPreview = document.getElementById("avatar_preview");
+  const avatarPreviewContainer = document.getElementById(
+    "avatar_preview_container"
+  );
+  const clearButton = document.getElementById("clear_avatar");
 
-  if (!avatarInput || !avatarPreview) return; // Avoids console errors on non avatar-uploading pages
+  if (!avatarInput || !avatarPreview || !clearButton) return; // Avoids console errors on non avatar-uploading pages
+
+  clearButton.disabled = true;
 
   avatarInput.addEventListener("change", function (event) {
     const file = event.target.files[0];
@@ -11,12 +17,21 @@ document.addEventListener("turbo:load", () => {
 
       reader.onload = function (e) {
         avatarPreview.src = e.target.result; // Set the preview source to the selected image
-        avatarPreview.style.display = "block"; // Show the image preview
+        avatarPreviewContainer.style.display = "block"; // Show the image preview
       };
 
       reader.readAsDataURL(file); // Read the file as a data URL
+
+      clearButton.disabled = !file;
     } else {
-      avatarPreview.style.display = "none"; // Hide the image preview if no file is selected
+      avatarPreviewContainer.style.display = "none"; // Hide the image preview if no file is selected
     }
+  });
+
+  clearButton.addEventListener("click", () => {
+    avatarInput.value = ""; // Clear the file input
+    avatarPreview.src = "";
+    avatarPreviewContainer.style.display = "none";
+    clearButton.disabled = true;
   });
 });

--- a/app/javascript/avatar_input_preview.js
+++ b/app/javascript/avatar_input_preview.js
@@ -2,6 +2,8 @@ document.addEventListener("turbo:load", () => {
   const avatarInput = document.getElementById("avatar_input");
   const avatarPreview = document.getElementById("avatar_preview");
 
+  if (!avatarInput || !avatarPreview) return; // Avoids console errors on non avatar-uploading pages
+
   avatarInput.addEventListener("change", function (event) {
     const file = event.target.files[0];
     if (file) {

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -49,8 +49,12 @@
          -->
           
         <!-- Preview new image -->
-        <div id="avatar_preview_container" style="margin-top: 10px;">
-          <img id="avatar_preview" src="#" alt="Image preview" style="display:none; max-width: 200px;"/>
+        <div id="avatar_preview_container" class="mt-2 position-relative" style="display:none; width: 200px;">
+          <img id="avatar_preview" src="#" alt="Image preview" style="max-width: 200px;"/>
+
+          <button type="button" class="btn btn-sm btn-outline-danger position-absolute m-1 rounded-circle" style="top: 0; right: 0" id="clear_avatar">
+            X
+          </button>
         </div>
 
         <%= f.file_field :avatar, class: "form-control", id: "avatar_input" %>


### PR DESCRIPTION
Why
--
- Console errors were thrown on all pages lacking the avatar uploader

How
--
- Early return if avatar uploading DOM elements are not rendered on current page