### PR TITLE
Update image uploader to validate file size and type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ gem "kaminari", "~> 1.2"
 
 gem "cloudinary"
 gem "carrierwave"
+gem "file_validators"
 gem "mini_magick" # processing images
 
 gem "dotenv-rails", groups: [ :development, :test ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,9 @@ GEM
     ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     ffi (1.17.1-x86_64-linux-musl)
+    file_validators (3.0.0)
+      activemodel (>= 3.2)
+      mime-types (>= 1.0)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -206,6 +209,10 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mime-types (3.6.2)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2025.0325)
     mini_magick (5.2.0)
       benchmark
       logger
@@ -445,6 +452,7 @@ DEPENDENCIES
   debug
   devise (~> 4.9)
   dotenv-rails
+  file_validators
   importmap-rails
   jbuilder
   kamal

--- a/app/javascript/image_input_preview.js
+++ b/app/javascript/image_input_preview.js
@@ -1,3 +1,7 @@
+const ALLOWED_TYPES = ["image/jpeg", "image/png"];
+const MAX_FILE_SIZE_MB = 1; // In megabytes
+const maxSizeBytes = MAX_FILE_SIZE_MB * 1024 * 1024;
+
 document.addEventListener("turbo:load", () => {
   const imageInput = document.getElementById("image_input");
   const imagePreview = document.getElementById("image_preview");
@@ -12,20 +16,38 @@ document.addEventListener("turbo:load", () => {
 
   imageInput.addEventListener("change", function (event) {
     const file = event.target.files[0];
-    if (file) {
-      const reader = new FileReader();
 
-      reader.onload = function (e) {
-        imagePreview.src = e.target.result; // Set the preview source to the selected image
-        imagePreviewContainer.style.display = "block"; // Show the image preview
-      };
-
-      reader.readAsDataURL(file); // Read the file as a data URL
-
-      clearButton.disabled = !file;
-    } else {
+    if (!file) {
       imagePreviewContainer.style.display = "none"; // Hide the image preview if no file is selected
+      return;
     }
+
+    // Validate type
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      alert("Only JPG and PNG images are allowed.");
+      imageInput.value = "";
+      imagePreviewContainer.style.display = "none";
+      return;
+    }
+
+    // Validate size
+    if (file.size > maxSizeBytes) {
+      alert(`File size must be less than ${MAX_FILE_SIZE_MB} MB.`);
+      imageInput.value = "";
+      imagePreviewContainer.style.display = "none";
+      return;
+    }
+
+    const reader = new FileReader();
+
+    reader.onload = function (e) {
+      imagePreview.src = e.target.result; // Set the preview source to the selected image
+      imagePreviewContainer.style.display = "block"; // Show the image preview
+    };
+
+    reader.readAsDataURL(file); // Read the file as a data URL
+
+    clearButton.disabled = !file;
   });
 
   clearButton.addEventListener("click", () => {

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -5,4 +5,7 @@ class Contact < ApplicationRecord
   has_many :tags, through: :contact_tags
 
   mount_uploader :profile_image, ImageUploader
+
+  validates :profile_image, file_size: { less_than_or_equal_to: 1000.kilobytes },
+      file_content_type: { allow: [ "image/jpeg", "image/png" ] }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
   has_many :contacts
 
   mount_uploader :avatar, ImageUploader
+  validates :avatar, file_size: { less_than_or_equal_to: 1000.kilobytes },
+      file_content_type: { allow: [ "image/jpeg", "image/png" ] }
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -10,6 +10,16 @@ class ImageUploader < CarrierWave::Uploader::Base
   else
     include Cloudinary::CarrierWave
 
+    # Whitelist extensions (safe fallback)
+    def extension_allowlist
+      %w[jpg jpeg png]
+    end
+
+    # Limit file size (fallback safety)
+    def size_range
+      1.kilobyte..1.megabyte
+    end
+
     # Optional Cloudinary transformations
     version :thumb do
       process resize_to_fill: [ 200, 200 ]


### PR DESCRIPTION
Why
--
- As a user uploading images, I should be informed as soon as possible if the file will be rejected by the server

How
--
- Add file_validators gem
- Update JS to validate image type and size prior to server submission
- Add image requirements to contact model
- Add image requirements to user model
- Update ImageUploader with fallback requirements
