### PR TITLE
Update Home UI, remove auth requirement for Home, test

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,14 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
-  before_action :authenticate_user!  # Force users to log in before accessing any page
+  before_action :authenticate_user!, unless: :public_page?
+
+  private
+  def public_page?
+    # Home page does not require auth
+    controller_name == "home" && [ "index" ].include?(action_name)
+  end
+
 
   # Redirect after sign-in
   def after_sign_in_path_for(resource)

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -3,7 +3,6 @@ class ContactsController < ApplicationController
   before_action :set_contact, only: %i[show edit update destroy]
   before_action :correct_user, only: [ :edit, :update, :destroy ]
 
-
   # GET /contacts or /contacts.json
   def index
     @page_size = 5

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,5 @@
 class HomeController < ApplicationController
+  # Home screen does NOT require auth, see application_controller
   def index
   end
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,19 @@
-<h1>Home#index</h1>
-<p>Hello world!</p>
-<p>Find me in app/views/home/index.html.erb</p>
+<h1>Welcome to Your Contact Manager!</h1>
+
+<p>Easily manage your personal and professional contacts all in one place. Our simple and powerful contact manager helps you store, search, and organize your connections effortlessly.</p>
+
+<section>
+  <span>Features:</span>
+  <ul>
+    <li>Secure, private contact storage 🔒</li>
+    <li>Tagging system for easy categorization 🏷️</li>
+    <li>Search and filter options to find contacts quickly 🔍</li>
+    <li>API support for developers 🚀</li>
+  </ul>
+</section>
+
+<% if !user_signed_in? %>
+  <div>👉 <%= link_to 'Sign Up', new_user_registration_path %> or <%= link_to 'Sign In', new_user_session_path %> to get started today!</div>
+<% else %>
+  <%= link_to 'View Contacts', contacts_path %>
+<% end %>

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -1,0 +1,31 @@
+require "application_system_test_case"
+
+class HomeTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:one)
+
+    sign_in @user
+  end
+
+  test "unauthenticated user is presented with links to sign up and sign in the main content" do
+    sign_out @user  # Manually sign out for this specific test
+    visit root_path
+
+    assert_text "Sign Up"
+    assert_text "Sign In"
+
+    assert_no_text "View Contacts"
+  end
+
+  test "authenticated user is NOT presented with links to sign up and sign in the main content" do
+    user = users(:one)
+
+    login_as(user, scope: :user)
+    visit root_path
+
+    assert_no_text "Sign Up"
+    assert_no_text "Sign In"
+
+    assert_text "View Contacts"
+  end
+end


### PR DESCRIPTION
Why
--
- As an unauthenticated user, I should see content explaining the benefits of the application
- As an authenticated user, I should have access to the content, but do not need the same auth links

How
--
- Update application controller to include an allow-list of public pages (limited to Home)
- Update home controller with comment doubling down on lack of auth requirement
- Update home html
- Test home