### PR TITLE
Update Brakement dep, resolve CI error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.0)
+    brakeman (7.0.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
Why
--
- The most recent [CI job failed](https://github.com/cflinchbaugh/ruby-contact-list/actions/runs/14271688265/job/40006161815) with the following error:
> Brakeman 7.0.0 is not the latest version 7.0.2