### PR TITLE
Feature/email/ux enhancements

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,5 +3,6 @@ import "controllers";
 
 // Custom code
 // IMPORTANT: Be sure to add to config/importmap.rb and restart the server to see the changes
+import "edit_user_current_password_tracker";
 import "filter_form_tracker";
 import "image_input_preview";

--- a/app/javascript/edit_user_current_password_tracker.js
+++ b/app/javascript/edit_user_current_password_tracker.js
@@ -1,0 +1,23 @@
+document.addEventListener("turbo:load", () => {
+  const currentPasswordInput = document.getElementById(
+    "current-password-input"
+  );
+  const updateSubmitButton = document.getElementById("update-profile-submit");
+
+  if (!currentPasswordInput || !updateSubmitButton) return;
+
+  const toggleSubmitButton = () => {
+    const hasValue = currentPasswordInput.value.trim().length > 0;
+    updateSubmitButton.disabled = !hasValue;
+
+    hasValue
+      ? updateSubmitButton.classList.remove("disabled")
+      : updateSubmitButton.classList.add("disabled");
+  };
+
+  // Initial check
+  toggleSubmitButton();
+
+  // Listen for input
+  currentPasswordInput.addEventListener("input", toggleSubmitButton);
+});

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -3,5 +3,3 @@
 <p>Thank you for signing up! To complete your registration, please click the link below to verify your email address:</p>
 
 <p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
-
-<p>Please note: It may take a few moments to load when you first visit. We appreciate your patience as the app finishes a cup of coffee and "wakes up" after a period of inactivity. We've all been there, I'm sure.</p>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,7 @@
 <p>Welcome <%= @email %>!</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p>Thank you for signing up! To complete your registration, please click the link below to verify your email address:</p>
 
 <p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+
+<p>Please note: It may take a few moments to load when you first visit. We appreciate your patience as the app finishes a cup of coffee and "wakes up" after a period of inactivity. We've all been there, I'm sure.</p>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -6,7 +6,7 @@
 
     <div class="field form-group">
       <%= f.label :current_password %> <i>*</i><br />
-      <%= f.password_field :current_password, class:"form-control", autocomplete: "current-password" %>
+      <%= f.password_field :current_password, id: "current-password-input", class:"form-control", autocomplete: "current-password" %>
     </div>
 
     <div class="field form-group">
@@ -30,7 +30,7 @@
     <%= render "layouts/image_uploader", form: f, field: :avatar %>
 
     <div class="actions">
-      <%= f.submit "Update", class:"btn btn-primary" %>
+      <%= f.submit "Update", id: "update-profile-submit", class:"btn btn-primary" %>
     </div>
   </div>
 <% end %>

--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -4,3 +4,5 @@
   
 
 <p>Created by <%= link_to "CF", "https://cflinchbaugh.github.io/portfolio/", target: "_blank", rel: "noopener noreferrer" %> with an emphasis on critical functionality and the most critical aspects of the majority of applications, everything from authentication, to user input, to testing.</p>
+
+<p><%= link_to "Github Repo", "https://github.com/cflinchbaugh/ruby-contact-list/", target: "_blank", rel: "noopener noreferrer" %></p>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,5 +6,6 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 
+pin "edit_user_current_password_tracker"
 pin "filter_form_tracker"
 pin "image_input_preview"

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -18,17 +18,17 @@ en:
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: "Ruby Contact List: Confirmation instructions"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "Ruby Contact List: Reset password instructions"
       unlock_instructions:
-        subject: "Unlock instructions"
+        subject: "Ruby Contact List: Unlock instructions"
       email_changed:
-        subject: "Email Changed"
+        subject: "Ruby Contact List: Email Changed"
       password_change:
-        subject: "Password Changed"
+        subject: "Ruby Contact List: Password Changed"
     omniauth_callbacks:
-      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      failure: 'Could not authenticate you from %{kind} because "%{reason}".'
       success: "Successfully authenticated from %{kind} account."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."


### PR DESCRIPTION
Why
--
- As a user editing my account, I should not be able to submit without including my current password for security reasons
- As a user receiving an email from the app, I should see a clear subject line

How
--
- Add edit user js to application.js
- Add js for enabling/disabling edit user save button
- Update verify email
- Update edit user page to include ids for JS targetting
- Update About content to link to repo
- Update importmap to include js
- Update email subjects to include app name