### PR TITLE
Update Contacts to default to private and support conditional PUBLIC visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ User-generated content (names, email, etc) is safely handled throughout the syst
 
 Image uploads are handled using CarrierWave, with files stored on Cloudinary. Uploaded images are restricted by file type and size using model-level validations. The application does not accept or render arbitrary file types, and uploads are not directly exposed or served from the Rails app, further mitigating risk.
 
+## Deployment
+
+Deployment is configured via [Render](https://www.render.com) and can be monitored via the [Dashboard](https://dashboard.render.com/). It is configured to automatically deploy each to `main` is updated.
+
+### Deployment Limitations
+
+Render's free tier does not maintain data across spin downs or deployments, which means it will almost certainly wipe all data between uses. This project's primary intent is to demonstrate fullstack skills so this is an acceptable limitation at this time, however inconvenient it may be.
+
 ## Misc
 
 When installing a new gem, be sure to run `bundle add <gem>` not `gem install <gem>` or it will not automatically be added to the Gemfile.

--- a/app/views/contacts/_form.html.erb
+++ b/app/views/contacts/_form.html.erb
@@ -31,7 +31,16 @@
       <%= form.label :phone, class:"form-label" %>
       <%= form.text_field :phone, class:"form-control" %>
     </div>    
-
+    
+    <div class="field form-group">
+      <%= form.check_box :is_public, class: "form-check-input" %>
+      <%= form.label :is_public, "Public" %>
+      </br>
+      <div class="p-2 mt-2 text-primary-emphasis bg-warning-subtle border border-primary-subtle rounded-3">
+        Public Contacts can be viewed by ANY user in the system
+      </div>
+    </div>
+  
     <div>
       <strong>Categories</strong>
       <br>

--- a/db/migrate/20250405012038_add_is_public_to_contacts.rb
+++ b/db/migrate/20250405012038_add_is_public_to_contacts.rb
@@ -1,0 +1,6 @@
+class AddIsPublicToContacts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :contacts, :is_public, :boolean, default: false
+    add_index :contacts, :is_public
+  end
+end


### PR DESCRIPTION
Why
--
- As a user adding Contacts, I should have the ability to share them- but the security of knowing they are private by default

How
--
- Update README to include a Deployment section
- Update Contacts Controller to support is_public
- Update Contact edit form to include is_public checkbox
- Add db migration adding is_public to Contacts, default to FALSE