### PR TITLE
Update rubocop config per error warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ group :development, :test do
   gem "brakeman", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
+  gem "rubocop", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
   gem "rubocop-rails-omakase", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -482,6 +482,9 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)
+  rubocop
+  rubocop-performance
+  rubocop-rails
   rubocop-rails-omakase
   selenium-webdriver
   simplecov


### PR DESCRIPTION
Why
--
- RuboCop used to include all cops (rules) for: Performance (e.g. using efficient methods or avoiding costly patterns) and Rails (e.g. best practices specific to Rails). But now, those cops have been moved to separate gems:
[rubocop-performance](https://github.com/rubocop/rubocop-performance)
[rubocop-rails](https://github.com/rubocop/rubocop-rails)

How
--
- Add gems


Notes
--
The error which led to this PR:
```
Running RuboCop Linting with safe autocorrect...
Inspecting 65 files
.................................................................

65 files inspected, no offenses detected
Staging files modified by RuboCop...
Checking for remaining RuboCop offenses...
Error: `Performance` cops have been extracted to the `rubocop-performance` gem.
(obsolete configuration found in /Users/cflinchbaugh/.local/share/mise/installs/ruby/3.4.2/lib/ruby/gems/3.4.0/gems/rubocop-rails-omakase-1.1.0/rubocop.yml, please update it)
`Rails` cops have been extracted to the `rubocop-rails` gem.
(obsolete configuration found in /Users/cflinchbaugh/.local/share/mise/installs/ruby/3.4.2/lib/ruby/gems/3.4.0/gems/rubocop-rails-omakase-1.1.0/rubocop.yml, please update it)
RuboCop Linter still found issues. Fix them before committing.
```